### PR TITLE
(Vanilla) Display characters in alphabetical order in recipes' tooltip

### DIFF
--- a/Vanilla/Source/Handlers/TooltipHandler.lua
+++ b/Vanilla/Source/Handlers/TooltipHandler.lua
@@ -67,12 +67,16 @@ local function getRecipeTooltipMessage(recipe, professionID)
     end
     if rm.getPreference("showAltsTooltipInfo") then
         if #charactersWhoCraftRecipe > 0 then
+            -- Sort the charactersWhoCraftRecipe table alphabetically
+            table.sort(charactersWhoCraftRecipe)
             message = message..newLine..WrapTextInColorCode(L.crafters, F.colors.lightGreenHex)
             for _, character in pairs(charactersWhoCraftRecipe) do
                 message = message..newLineInfo..character
             end
         end
         if #charactersMissingRecipe > 0 then
+            -- Sort the charactersMissingRecipe table alphabetically
+            table.sort(charactersMissingRecipe)
             message = message..newLine..WrapTextInColorCode(L.unlearned, F.colors.lightPinkHex)
             for _, character in pairs(charactersMissingRecipe) do
                 local characterLine = newLineInfo..character.." ("
@@ -83,6 +87,7 @@ local function getRecipeTooltipMessage(recipe, professionID)
                 message = message..characterLine..")"
             end
         end
+
     end
     return rm.L.title..WrapTextInColorCode(message, F.colors.whiteHex)
 end


### PR DESCRIPTION
Makes the alts alphabetized. (=

<img width="499" alt="image" src="https://github.com/user-attachments/assets/8712e819-d338-4ff1-91cd-7977408510c2">

https://github.com/BrenoLudgero/Recipe_Master/issues/13