### PR TITLE
Update interface version in RecipeMaster_Vanilla.toc

### DIFF
--- a/Vanilla/RecipeMaster_Vanilla.toc
+++ b/Vanilla/RecipeMaster_Vanilla.toc
@@ -1,4 +1,4 @@
-## Interface: 11507
+## Interface: 11508
 ## Version: @project-version@
 
 ## X-WoWI-ID: 26887


### PR DESCRIPTION
Add-on was totally unusable without this fix! (=

Ha, no it all works fine. Just updating to match the new Game Client Version.